### PR TITLE
Fix SKIP_CHOWN_CONFIG directive to work as advertised

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -24,7 +24,7 @@ fi
 
 usermod -a -G ${GROUP} plex
 
-if [[ -z "${SKIP_CHOWN_CONFIG}" ]]; then
+if [[ -n "${SKIP_CHOWN_CONFIG}" ]]; then
   CHANGE_CONFIG_DIR_OWNERSHIP=false
 fi
 


### PR DESCRIPTION
`-z` in bash tests for an empty string, so the only way the previous conditional would be true is if SKIP_CHOWN_CONFIG is empty or undefined.