### PR TITLE
Automatically connect you Plex account to the container without SSH Port Forward or other tricks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup &&\
     apt-get install -qy --force-yes \
       ca-certificates curl \
       openssl \
+      xmlstarlet \
+      curl \
       sudo \
     && \
     echo "deb http://shell.ninthgate.se/packages/debian wheezy main" > /etc/apt/sources.list.d/plexmediaserver.list && \
@@ -25,6 +27,7 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup &&\
 VOLUME ["/config","/data"]
 
 ADD ./start.sh /start.sh
+ADD ./Preferences.xml /Preferences.xml
 RUN chmod u+x  /start.sh
 
 ENV RUN_AS_ROOT="true" \

--- a/Preferences.xml
+++ b/Preferences.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Preferences ManualPortMappingMode="1" AcceptedEULA="1" PublishServerOnPlexOnlineKey="1" />

--- a/start.sh
+++ b/start.sh
@@ -38,6 +38,36 @@ if [ "${CHANGE_DIR_RIGHTS}" = true ]; then
   chmod -R g+rX /data
 fi
 
+# Get plex token if PLEX_USERNAME and PLEX_PASSWORD are define
+[ "${PLEX_USERNAME}" ] && [ "${PLEX_PASSWORD}" ] && {
+
+  # Ask Plex.tv a token key
+  TOKEN=$(curl -u "${PLEX_USERNAME}":"${PLEX_PASSWORD}" 'https://plex.tv/users/sign_in.xml' \
+    -X POST -H 'X-Plex-Device-Name: PlexMediaServer' \
+    -H 'X-Plex-Provides: server' \
+    -H 'X-Plex-Version: 0.9' \
+    -H 'X-Plex-Platform-Version: 0.9' \
+    -H 'X-Plex-Platform: xcid' \
+    -H 'X-Plex-Product: Plex Media Server'\
+    -H 'X-Plex-Device: Linux'\
+    -H 'X-Plex-Client-Identifier: XXXX' --compressed | sed -n 's/.*<authentication-token>\(.*\)<\/authentication-token>.*/\1/p')
+
+  if [ ! -f /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml ]; then
+    mkdir -p /config/Library/Application\ Support/Plex\ Media\ Server/
+    cp /Preferences.xml /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
+  fi
+
+  if [ ! $(xmlstarlet sel -T -t -m "/Preferences" -v "@PlexOnlineToken" -n /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml) ]; then
+    xmlstarlet ed --inplace --insert "Preferences" --type attr -n PlexOnlineToken -v ${TOKEN} /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
+  fi
+
+  if [ "${PLEX_EXTERNALPORT}" ]; then
+    xmlstarlet ed --inplace --insert "Preferences" --type attr -n ManualPortMappingPort -v ${PLEX_EXTERNALPORT} /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
+  fi
+
+}
+
+
 # Current defaults to run as root while testing.
 if [ "${RUN_AS_ROOT}" = true ]; then
   /usr/sbin/start_pms


### PR DESCRIPTION
Automatically connect you Plex account to the container without SSH Port Forward or other tricks.

Username and password are used to cat Plex.tv api to get an app token. Then add it to Preferences.xml and your Plex Media is Automatically linked to your account

ENV Variables to use :
``PLEX_USERNAME``
``PLEX_PASSWORD``

example : 
```
docker run -d --name plex \ 
              -e PLEX_USERNAME=xcid  \
              -e PLEX_PASSWORD=password  \ 
              -h *your_host_name* \ 
              -v /*your_config_location*:/config \ 
              -v /*your_videos_location*:/data \ 
              -p 32400:32400  timhaak/plex 
```

If you are using a different external port than 32400, you will have to user ```PLEX_EXTERNALPORT```
```
docker run -d --name plex \ 
              -e PLEX_USERNAME=xcid  \
              -e PLEX_PASSWORD=password  \ 
              -e PLEX_EXTERNALPORT=33400  \
              -h *your_host_name* \ 
              -v /*your_config_location*:/config \ 
              -v /*your_videos_location*:/data \ 
              -p 33400:32400  timhaak/plex 
```