### PR TITLE
Updated the documentation for docker 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Instructions to run:
 
 ```
 docker rm -f plex
-docker run --restart=always -d --name plex -h *your_host_name* -v /*your_config_location*:/config -v /*your_videos_location*:/data -p 32400:32400  timhaak/plex
+docker run --restart=always -d --name plex -h *your_host_name* -v /*your_config_location*:/config -v /*your_videos_location*:/data -p 32400:32400 timhaak/plex
 ```
 or for auto detection to work add --net="host". Though be aware this more insecure and not best practice with docker images.
 
@@ -33,7 +33,7 @@ See https://docs.docker.com/articles/networking/#how-docker-networks-a-container
 
 ```
 docker rm -f plex
-docker run --restart=always -d --name plex --net="host" -h *your_host_name* -v /*your_config_location*:/config -v /*your_videos_location*:/data -p 32400:32400  timhaak/plex
+docker run --restart=always -d --name plex --net="host" -h *your_host_name* -v /*your_config_location*:/config -v /*your_videos_location*:/data timhaak/plex
 ```
 
 The first time it runs, it will initialize the config directory and terminate. (This most likely won't happen if you've used the --net="host")


### PR DESCRIPTION
In previous versions of docker, specifying a `-p` flag along with `--net=host` was ignored. After the networking updates in docker 1.9, these now conflict and docker will not start the container. This change is backwards compatible since the `-p` flag has always been ignored when specified with `--net=host`.

Fixes #43