### PR TITLE
Reduce the command injection attack space

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -64,9 +64,9 @@ fi
 
 function setConfig(){
   if [ -z "$(xmlstarlet sel -T -t -m "/Preferences" -v "@$1" -n /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml)" ]; then
-    xmlstarlet ed --inplace --insert "Preferences" --type attr -n $1 -v $2 /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
+    xmlstarlet ed --inplace --insert "Preferences" --type attr -n "$1" -v "$2" /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
   else
-    xmlstarlet ed --inplace --update "/Preferences[@$1]" -v $2 /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
+    xmlstarlet ed --inplace --update "/Preferences[@$1]" -v "$2" /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
   fi
 }
 

--- a/start.sh
+++ b/start.sh
@@ -11,18 +11,18 @@ chown plex: /supervisord.log /supervisord.pid
 # Get the proper group membership, credit to http://stackoverflow.com/a/28596874/249107
 
 TARGET_GID=$(stat -c "%g" /data)
-EXISTS=$(cat /etc/group | grep ${TARGET_GID} | wc -l)
+EXISTS=$(cat /etc/group | grep "${TARGET_GID}" | wc -l)
 
 # Create new group using target GID and add plex user
-if [ $EXISTS = "0" ]; then
-  groupadd --gid ${TARGET_GID} ${GROUP}
+if [ "$EXISTS" = "0" ]; then
+  groupadd --gid "${TARGET_GID}" "${GROUP}"
 else
   # GID exists, find group name and add
-  GROUP=$(getent group $TARGET_GID | cut -d: -f1)
-  usermod -a -G ${GROUP} plex
+  GROUP=$(getent group "$TARGET_GID" | cut -d: -f1)
+  usermod -a -G "${GROUP}" plex
 fi
 
-usermod -a -G ${GROUP} plex
+usermod -a -G "${GROUP}" plex
 
 if [[ -n "${SKIP_CHOWN_CONFIG}" ]]; then
   CHANGE_CONFIG_DIR_OWNERSHIP=false
@@ -34,7 +34,7 @@ fi
 
 # Will change all files in directory to be readable by group
 if [ "${CHANGE_DIR_RIGHTS}" = true ]; then
-  chgrp -R ${GROUP} /data
+  chgrp -R "${GROUP}" /data
   chmod -R g+rX /data
 fi
 
@@ -63,18 +63,18 @@ fi
 }
 
 if [ "${PLEX_TOKEN}" ]; then
-  xmlstarlet ed --inplace --insert "Preferences" --type attr -n PlexOnlineToken -v ${PLEX_TOKEN} /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
+  xmlstarlet ed --inplace --insert "Preferences" --type attr -n PlexOnlineToken -v "${PLEX_TOKEN}" /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
 fi
 
 # Tells Plex the external port is not "32400" but something else.
 # Useful if you run multiple Plex instances on the same IP
 if [ "${PLEX_EXTERNALPORT}" ]; then
-  xmlstarlet ed --inplace --insert "Preferences" --type attr -n ManualPortMappingPort -v ${PLEX_EXTERNALPORT} /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
+  xmlstarlet ed --inplace --insert "Preferences" --type attr -n ManualPortMappingPort -v "${PLEX_EXTERNALPORT}" /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
 fi
 
 # Allow disabling the remote security (hidding the Server tab in Settings)
 if [ "${PLEX_DISABLE_SECURITY}" ]; then
-  xmlstarlet ed --inplace --insert "Preferences" --type attr -n disableRemoteSecurity -v ${PLEX_DISABLE_SECURITY} /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
+  xmlstarlet ed --inplace --insert "Preferences" --type attr -n disableRemoteSecurity -v "${PLEX_DISABLE_SECURITY}" /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
 fi
 
 # Detect networks and add them to the allowed list of networks
@@ -82,7 +82,7 @@ if [ -z "${PLEX_ALLOWED_NETWORKS}" ]; then
   PLEX_ALLOWED_NETWORKS=$(ip route | grep "/" | awk '{print $1}' | paste -sd "," -)
 fi
 if [ -n "${PLEX_ALLOWED_NETWORKS}" ]; then
-  xmlstarlet ed --inplace --insert "Preferences" --type attr -n allowedNetworks -v ${PLEX_ALLOWED_NETWORKS} /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
+  xmlstarlet ed --inplace --insert "Preferences" --type attr -n allowedNetworks -v "${PLEX_ALLOWED_NETWORKS}" /config/Library/Application\ Support/Plex\ Media\ Server/Preferences.xml
 fi
 
 #remove previous pid if it exists


### PR DESCRIPTION
Not really a major deal but I just feel it's best not to trust user input ever, even if it's not that much a big deal in a container and that the exploit will only be executable by the person starting the container.

All variable expansions provided by environment variables that can be set by the user have been wrapped in double quotes ensuring that no matter of the contents it will be treated as 1 argument where used (no less, no more).

Also makes the commands a little more resilient to failure if empty values sneak past the `-z`/`-n` checks. Where `[ "${VAR}" ]` has been used (without `-z` or `-n`) they _will_ get past but I am fixing this in another code cleanup PR.