### PR TITLE
Moved start script defaults, to the start script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,15 +26,11 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup &&\
     rm -rf /tmp/*
 
 VOLUME ["/config","/data"]
+ENV HOME="/config"
 
 ADD ./start.sh /start.sh
 ADD ./Preferences.xml /Preferences.xml
 RUN chmod u+x  /start.sh
-
-ENV RUN_AS_ROOT="true" \
-    CHANGE_DIR_RIGHTS="false" \
-    CHANGE_CONFIG_DIR_OWNERSHIP="true" \
-    HOME="/config"
 
 EXPOSE 32400
 

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -x
+
+# Set the defaults
+RUN_AS_ROOT=${RUN_AS_ROOT:-true}
+CHANGE_DIR_RIGHTS=${CHANGE_DIR_RIGHTS:-false}
+CHANGE_CONFIG_DIR_OWNERSHIP=${CHANGE_CONFIG_DIR_OWNERSHIP:-true}
+
 GROUP=plextmp
 
 mkdir -p /config/logs/supervisor


### PR DESCRIPTION
Less to build in the Dockerfile. Keeps management of the start script and related features within the `start.sh` file.