### PR TITLE
Faster cached build for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ ENV HOME="/config"
 
 ADD ./start.sh /start.sh
 ADD ./Preferences.xml /Preferences.xml
-RUN chmod u+x  /start.sh
 
 EXPOSE 32400
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,15 +26,11 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup &&\
     rm -rf /tmp/*
 
 VOLUME ["/config","/data"]
+ENV HOME="/config"
 
 ADD ./start.sh /start.sh
 ADD ./Preferences.xml /Preferences.xml
 RUN chmod u+x  /start.sh
-
-ENV RUN_AS_ROOT="true" \
-    CHANGE_DIR_RIGHTS="false" \
-    CHANGE_CONFIG_DIR_OWNERSHIP="true" \
-    HOME="/config"
 
 EXPOSE 32400
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup &&\
 VOLUME ["/config","/data"]
 ENV HOME="/config"
 
-ADD ./start.sh /start.sh
-ADD ./Preferences.xml /Preferences.xml
-
 EXPOSE 32400
+
+ADD ./Preferences.xml /Preferences.xml
+ADD ./start.sh /start.sh
 
 CMD ["/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -x
+
+# Set the defaults
+RUN_AS_ROOT=${RUN_AS_ROOT:-true}
+CHANGE_DIR_RIGHTS=${CHANGE_DIR_RIGHTS:-false}
+CHANGE_CONFIG_DIR_OWNERSHIP=${CHANGE_CONFIG_DIR_OWNERSHIP:-true}
+
 GROUP=plextmp
 
 mkdir -p /config/logs/supervisor


### PR DESCRIPTION
Made cached builds faster by reordering the `Dockerfile` directives. Builds on #50 so accepting this accepts #50 too. Since most of the development for this image revolves around changes in the `start.sh` file, having this added as the last thing as well as removing the unessasary chmod speeds up rebuilidng making testing quicker and easier.