### PR TITLE
Only set -x if DEBUG environment var is "true"

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-set -x
+
+# If debug mode, then enable xtrace
+if [ "${DEBUG,,}" = "true" ]; then
+  set -x
+fi
+
 GROUP=plextmp
 
 mkdir -p /config/logs/supervisor


### PR DESCRIPTION
Only enables xtrace in the start.sh script if a `DEBUG` environment variable is set to true. Cleaner logs for end user while maintaining what is an extremely useful tool for debugging.