### PR TITLE
Create group and change permissions only if we are root

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -11,12 +11,6 @@ CHANGE_CONFIG_DIR_OWNERSHIP=${CHANGE_CONFIG_DIR_OWNERSHIP:-true}
 
 GROUP=plextmp
 
-mkdir -p /config/logs/supervisor
-
-touch /supervisord.log
-touch /supervisord.pid
-chown plex: /supervisord.log /supervisord.pid
-
 # Get the proper group membership, credit to http://stackoverflow.com/a/28596874/249107
 
 TARGET_GID=$(stat -c "%g" /data)

--- a/start.sh
+++ b/start.sh
@@ -12,9 +12,8 @@ CHANGE_CONFIG_DIR_OWNERSHIP=${CHANGE_CONFIG_DIR_OWNERSHIP:-true}
 GROUP=plextmp
 
 # Get the proper group membership, credit to http://stackoverflow.com/a/28596874/249107
-
 TARGET_GID=$(stat -c "%g" /data)
-EXISTS=$(cat /etc/group | grep "${TARGET_GID}" | wc -l)
+EXISTS=$(getent group "${TARGET_GID}" | wc -l)
 
 # Create new group using target GID and add plex user
 if [ "$EXISTS" = "0" ]; then
@@ -22,7 +21,6 @@ if [ "$EXISTS" = "0" ]; then
 else
   # GID exists, find group name and add
   GROUP=$(getent group "$TARGET_GID" | cut -d: -f1)
-  usermod -a -G "${GROUP}" plex
 fi
 
 usermod -a -G "${GROUP}" plex
@@ -64,12 +62,8 @@ setPreference(){
 
 if [ ! -f "${PLEX_PREFERENCES}" ]; then
   mkdir -p "$(dirname "${PLEX_PREFERENCES}")"
-  ls -la "$(dirname "${PLEX_PREFERENCES}")"
-  PLEX_PREFERENCES_DIR=$(dirname "${PLEX_PREFERENCES}")
   cp /Preferences.xml "${PLEX_PREFERENCES}"
 fi
- 
-ls -la "$(dirname "${PLEX_PREFERENCES}")"
 
 # Set the PlexOnlineToken to PLEX_TOKEN if defined,
 # otherwise get plex token if PLEX_USERNAME and PLEX_PASSWORD are defined,
@@ -113,7 +107,7 @@ PLEX_ALLOWED_NETWORKS=${PLEX_ALLOWED_NETWORKS:-$(ip route | grep '/' | awk '{pri
 
 
 # Remove previous pid if it exists
-rm "${PLEX_PID}"
+rm -f "${PLEX_PID}"
 
 # Current defaults to run as root while testing.
 if [ "${RUN_AS_ROOT,,}" = "true" ]; then

--- a/start.sh
+++ b/start.sh
@@ -9,34 +9,34 @@ RUN_AS_ROOT=${RUN_AS_ROOT:-true}
 CHANGE_DIR_RIGHTS=${CHANGE_DIR_RIGHTS:-false}
 CHANGE_CONFIG_DIR_OWNERSHIP=${CHANGE_CONFIG_DIR_OWNERSHIP:-true}
 
-GROUP=plextmp
+if [ "$(id -u)" -eq 0 -a "$(id -g)" -eq 0 ]; then
+  GROUP=plextmp
+  TARGET_GID=$(stat -c "%g" /data)
+  EXISTS=$(getent group "${TARGET_GID}" | wc -l)
 
-# Get the proper group membership, credit to http://stackoverflow.com/a/28596874/249107
-TARGET_GID=$(stat -c "%g" /data)
-EXISTS=$(getent group "${TARGET_GID}" | wc -l)
+  # Create new group using target GID and add plex user
+  if [ "$EXISTS" = "0" ]; then
+    groupadd --gid "${TARGET_GID}" "${GROUP}"
+  else
+    # GID exists, find group name and add
+    GROUP=$(getent group "$TARGET_GID" | cut -d: -f1)
+  fi
 
-# Create new group using target GID and add plex user
-if [ "$EXISTS" = "0" ]; then
-  groupadd --gid "${TARGET_GID}" "${GROUP}"
-else
-  # GID exists, find group name and add
-  GROUP=$(getent group "$TARGET_GID" | cut -d: -f1)
-fi
+  usermod -a -G "${GROUP}" plex
 
-usermod -a -G "${GROUP}" plex
+  if [[ -n "${SKIP_CHOWN_CONFIG}" ]]; then
+    CHANGE_CONFIG_DIR_OWNERSHIP=false
+  fi
 
-if [[ -n "${SKIP_CHOWN_CONFIG}" ]]; then
-  CHANGE_CONFIG_DIR_OWNERSHIP=false
-fi
+  if [ "${CHANGE_CONFIG_DIR_OWNERSHIP,,}" = "true" ]; then
+    find /config ! -user plex -print0 | xargs -0 -I{} chown -R plex: {}
+  fi
 
-if [ "${CHANGE_CONFIG_DIR_OWNERSHIP,,}" = "true" ]; then
-  find /config ! -user plex -print0 | xargs -0 -I{} chown -R plex: {}
-fi
-
-# Will change all files in directory to be readable by group
-if [ "${CHANGE_DIR_RIGHTS,,}" = "true" ]; then
-  chgrp -R "${GROUP}" /data
-  chmod -R g+rX /data
+  # Will change all files in directory to be readable by group
+  if [ "${CHANGE_DIR_RIGHTS,,}" = "true" ]; then
+    chgrp -R "${GROUP}" /data
+    chmod -R g+rX /data
+  fi
 fi
 
 # Preferences


### PR DESCRIPTION
If I run this container with `-u $(id -u):$(id -g)` I get a lot of `Permission denied` errors because it tries to do things that only root can do.