### PR TITLE
Fix xmlstarlet update bug

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -64,7 +64,7 @@ setPreference(){
   if [ -z "$(getPreference "$preference_key")" ]; then
     xmlstarlet ed --inplace --insert "Preferences" --type attr -n "$preference_key" -v "$preference_val" "${PLEX_PREFERENCES}"
   else
-    xmlstarlet ed --inplace --update "/Preferences[@$preference_key]" -v "$preference_val" "${PLEX_PREFERENCES}"
+    xmlstarlet ed --inplace --update "/Preferences[@$preference_key]/$preference_key" -v "$preference_val" "${PLEX_PREFERENCES}"
   fi
 }
 


### PR DESCRIPTION
Per documentation [here](http://xmlstar.sourceforge.net/doc/xmlstarlet.pdf), when editing an attribute you need to target that attribute directly. 

The previous code targeted a `Preferences` element with a `$preference_key` attribute. The new code targets that attribute itself.