### PR TITLE
Minor fixes to scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ENV RUN_AS_ROOT="true" \
 
 EXPOSE 32400
 
-ADD ./Preferences.xml /Preferences.xml
-ADD ./start.sh /start.sh
+COPY ./Preferences.xml /Preferences.xml
+COPY ./start.sh /start.sh
 
 CMD ["/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -68,9 +68,11 @@ fi
 # Set the PlexOnlineToken to PLEX_TOKEN if defined,
 # otherwise get plex token if PLEX_USERNAME and PLEX_PASSWORD are defined,
 # otherwise account must be manually linked via Plex Media Server in Settings > Server
-echo "PLEX_TOKEN :"${PLEX_TOKEN}
-echo "PLEX_USERNAME :"${PLEX_USERNAME}
-echo "PLEX_PASSWORD :"${PLEX_PASSWORD}
+if [ "${DEBUG,,}" = "true" ]; then
+  echo "PLEX_TOKEN :"${PLEX_TOKEN}
+  echo "PLEX_USERNAME :"${PLEX_USERNAME}
+  echo "PLEX_PASSWORD :"${PLEX_PASSWORD}
+fi
 if [ -n "${PLEX_TOKEN}" ]; then
   setPreference PlexOnlineToken ${PLEX_TOKEN}
 elif [ -n "${PLEX_USERNAME}" ] && [ -n "${PLEX_PASSWORD}" ] && [ -z "$(getPreference "PlexOnlineToken")" ]; then
@@ -86,9 +88,11 @@ elif [ -n "${PLEX_USERNAME}" ] && [ -n "${PLEX_PASSWORD}" ] && [ -z "$(getPrefer
     -H 'X-Plex-Client-Identifier: XXXX' --compressed | sed -n 's/.*<authentication-token>\(.*\)<\/authentication-token>.*/\1/p')
 fi
 
-echo "AFTER PLEX_TOKEN :"${PLEX_TOKEN}
-echo "PLEX_USERNAME :"${PLEX_USERNAME}
-echo "PLEX_PASSWORD :"${PLEX_PASSWORD}
+if [ "${DEBUG,,}" = "true" ]; then
+  echo "AFTER PLEX_TOKEN :"${PLEX_TOKEN}
+  echo "PLEX_USERNAME :"${PLEX_USERNAME}
+  echo "PLEX_PASSWORD :"${PLEX_PASSWORD}
+fi
 
 if [ "${PLEX_TOKEN}" ]; then
   setPreference PlexOnlineToken "${PLEX_TOKEN}"


### PR DESCRIPTION
This PR is for a couple of minor changes to the scripts.
- The docker documentation notes that `COPY` is preferred when adding local files. 
- Credentials shouldn't be logged (except for debug)