### PR TITLE
Fixed docker --env-file option example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ docker run -e RUN_AS_ROOT=TRUE ... timhaak/plex
 or add it to an envfile that can be included through the command line:
 
 ```
-docker run --envfile=*filename* ... timhaak/plex
+docker run --env-file=*filename* ... timhaak/plex
 ```
 
 ## Mac and Apple TV Usage


### PR DESCRIPTION
A simple change to correctly demonstrate the --env-file option.