### PR TITLE
Move to using plex token for installing plexpass version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,9 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup &&\
     rm -rf /tmp/*
 
 ARG PLEX_PASS='false'
-ARG PLEX_USER_NAME=''
-ARG PLEX_USER_PASS=''
+ARG PLEX_TOKEN=''
 
-RUN if [ "${PLEX_PASS}" = "true" ]; then PLEX_TYPE_FLAG="--email=${PLEX_USER_NAME} --pass=${PLEX_USER_PASS}" ; fi && \
+RUN if [ "${PLEX_PASS}" = "true" ]; then PLEX_TYPE_FLAG="--token=${PLEX_TOKEN}" ; fi && \
     git clone --depth 1 https://github.com/mrworf/plexupdate.git /plexupdate && \
     /plexupdate/plexupdate.sh ${PLEX_TYPE_FLAG} -a -d  && \
     apt-get -y purge git &&\


### PR DESCRIPTION
Installing `plexpass` version has been broken since https://github.com/mrworf/plexupdate/pull/169 which actually in itself is buggy. @mrworf did deprecate username/pass support in it but kept the actual support. 

Problem is that https://github.com/mrworf/plexupdate/blob/483f9b06f7e17d742a04b0f5a74f42d8fbeb7486/plexupdate.sh#L338 references older implementation that was moved to https://github.com/mrworf/plexupdate/blob/master/plexupdate-core

I'll do a another PR for `plexupdate` but thought to do this workaround here first since its the "correct" way to use the tool now.

So tl;dr
Move from Username/pass to token for installing plexpass version


Without the fix: 

```
 ---> Running in 26f0d6155781
Cloning into '/plexupdate'...
WARNING: EMAIL is deprecated. Use TOKEN instead.
WARNING: PASS is deprecated. Use TOKEN instead.
ERROR: Unable to get Plex token, falling back to public release
Retrieving list of available distributions
Downloading release "plexmediaserver_1.5.6.3790-4613ce077_amd64.deb"
```

Notice how no output from https://github.com/mrworf/plexupdate/blob/master/plexupdate-core#L32-L65 eg it was never hit due to wrong `source`

After this PR:

```
 ---> Running in 7d41d767e7f2
Cloning into '/plexupdate'...
Retrieving list of available distributions
Downloading release "plexmediaserver_1.7.3.3937-70f781325_amd64.deb"
```